### PR TITLE
Target JDK8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ buildscript {
 }
 
 plugins {
-  id("com.github.gmazzo.buildconfig") version "3.1.0" apply false
+  alias(libs.plugins.buildconfig)
   alias(libs.plugins.spotless)
 }
 
@@ -41,9 +41,7 @@ configure<SpotlessExtension> {
     ktlint()
       .editorConfigOverride(
         mapOf(
-          "ktlint_standard_comment-spacing" to "disabled", // TODO Re-enable
           "ktlint_standard_filename" to "disabled",
-          "ktlint_standard_indent" to "disabled", // TODO Re-enable
         )
       )
   }
@@ -82,7 +80,7 @@ allprojects {
         Visibility.PROTECTED
       ))
       reportUndocumented.set(false)
-      jdkVersion.set(11)
+      jdkVersion.set(8)
 
       perPackageOption {
         matchingRegex.set("app\\.cash\\.burst\\.internal\\..*")
@@ -104,21 +102,13 @@ allprojects {
 
   plugins.withId("org.jetbrains.kotlin.multiplatform") {
     configure<KotlinMultiplatformExtension> {
-      jvmToolchain(11)
-      // https://youtrack.jetbrains.com/issue/KT-61573
-      targets.configureEach {
-        compilations.configureEach {
-          compilerOptions.configure {
-            freeCompilerArgs.addAll("-Xexpect-actual-classes")
-          }
-        }
-      }
+      jvmToolchain(8)
     }
   }
 
   plugins.withId("org.jetbrains.kotlin.jvm") {
     configure<KotlinJvmProjectExtension> {
-      jvmToolchain(11)
+      jvmToolchain(8)
     }
   }
 

--- a/burst-kotlin-plugin-tests/build.gradle.kts
+++ b/burst-kotlin-plugin-tests/build.gradle.kts
@@ -10,6 +10,4 @@ dependencies {
   testImplementation(kotlin("test-junit"))
   testImplementation(libs.assertk)
   testImplementation(libs.kotlin.compile.testing)
-  testImplementation(libs.kotlin.reflect)
-  testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,20 @@
 [versions]
 kotlin = "2.0.21"
-kotlinx-coroutines = "1.9.0"
 
 [libraries]
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
-auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "1.2.0" }
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version = "1.1.1" }
+auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "1.2.0" }
 binary-compatibility-validator-gradle-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.16.3" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 google-ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:2.0.21-1.0.25"
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mavenPublish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.30.0" }
 
 [plugins]
+buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 burst-kotlin = { id = "app.cash.burst.kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+}
+
 rootProject.name = "burst-root"
 
 include(":burst")


### PR DESCRIPTION
This library is consumed by Okio which is extremely strict on which JDKs it targets. We don't need anything newer anyway.

Closes: https://github.com/cashapp/burst/issues/24