### PR TITLE
Set compilation targets instead of JVM toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,10 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.DokkaConfiguration.Visibility
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 buildscript {
   repositories {
@@ -100,15 +102,25 @@ allprojects {
     enabled = project.findProperty("signingInMemoryKey") != null
   }
 
+  val javaVersion = JavaVersion.VERSION_1_8
+
   plugins.withId("org.jetbrains.kotlin.multiplatform") {
-    configure<KotlinMultiplatformExtension> {
-      jvmToolchain(8)
+    val kotlin = extensions.getByName("kotlin") as KotlinMultiplatformExtension
+    kotlin.targets.withType(KotlinJvmTarget::class.java) {
+      compilerOptions {
+        freeCompilerArgs.add("-Xjdk-release=$javaVersion")
+      }
     }
   }
 
-  plugins.withId("org.jetbrains.kotlin.jvm") {
-    configure<KotlinJvmProjectExtension> {
-      jvmToolchain(8)
+  tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = javaVersion.toString()
+    targetCompatibility = javaVersion.toString()
+  }
+
+  tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.fromTarget(javaVersion.toString()))
     }
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
-}
-
 rootProject.name = "burst-root"
 
 include(":burst")


### PR DESCRIPTION
The JDK 8 toolchain is particularly problematic on macOS + aarch64, since by default it uses an X64 JDK.