### PR TITLE
Add a failing test for JUnit 5 extensions

### DIFF
--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
@@ -21,11 +21,13 @@ import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isIn
+import assertk.assertions.matches
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.presetName
+import org.junit.Ignore
 import org.junit.Test
 
 class BurstGradlePluginTest {
@@ -282,6 +284,34 @@ class BurstGradlePluginTest {
         "orgJunitTest_Milk",
         "orgJunitTest_None",
         "orgJunitTest_Oat",
+      )
+    }
+  }
+
+  @Test
+  @Ignore("mixing JUnit 5 and Burst parameters is not supported")
+  fun junit5Extensions() {
+    val projectDir = File("src/test/projects/junit5Extensions")
+
+    val taskName = ":lib:test"
+    val result = createRunner(projectDir, "clean", taskName).build()
+    assertThat(result.task(taskName)!!.outcome).isIn(*SUCCESS_OUTCOMES)
+
+    val testResults = projectDir.resolve("lib/build/test-results")
+
+    with(readTestSuite(testResults.resolve("test/TEST-TempDirTest.xml"))) {
+      assertThat(testCases.map { it.name }).containsExactlyInAnyOrder(
+        "test()",
+        "test_b()",
+      )
+      assertThat(systemOut).matches(
+        Regex(
+          """
+          |running \S+ b
+          |running \S+ a
+          |
+          """.trimMargin()
+        )
       )
     }
   }

--- a/burst-gradle-plugin/src/test/projects/junit5Extensions/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/junit5Extensions/build.gradle.kts
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+buildscript {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath("app.cash.burst:burst-gradle-plugin:${project.property("burstVersion")}")
+    classpath(libs.kotlin.gradlePlugin)
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+
+  tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+  }
+
+  tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+  }
+
+  tasks.withType<Test> {
+    useJUnitPlatform()
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/junit5Extensions/lib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/junit5Extensions/lib/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  kotlin("jvm")
+  id("app.cash.burst")
+}
+
+dependencies {
+  testImplementation(kotlin("test"))
+  testImplementation(libs.junit)
+}

--- a/burst-gradle-plugin/src/test/projects/junit5Extensions/lib/src/test/kotlin/TempDirTest.kt
+++ b/burst-gradle-plugin/src/test/projects/junit5Extensions/lib/src/test/kotlin/TempDirTest.kt
@@ -1,0 +1,16 @@
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import java.io.File
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+@Burst
+class TempDirTest {
+  @Test
+  fun test(
+    @TempDir tempDir: File,
+    string: String = burstValues("a", "b"),
+  ) {
+    println("running $tempDir $string")
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/junit5Extensions/settings.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/junit5Extensions/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":lib")


### PR DESCRIPTION
I looked into implementing this and it gets ugly quite quickly. I believe the best implementation applies Burst's transformation only to recognized parameters (enums, booleans, burstValues) and preserves existing behavior otherwise. Unfortunately the code to implement this is pretty tricky.

I've decided to not implement this behavior for now. If it's requested we can reconsider.