### PR TITLE
Add compatibility with Kotlin 2.1.0

### DIFF
--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/Argument.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/Argument.kt
@@ -188,7 +188,7 @@ private fun burstValuesArguments(
 @UnsafeDuringIrConstructionAPI
 private fun IrExpression.suggestedName(): String? {
   val raw = when (this) {
-    is IrConst<*> -> value.toString()
+    is IrConst -> value.toString()
     is IrCall -> {
       val target = (symbol.owner.correspondingPropertySymbol?.owner ?: symbol.owner)
       target.name.asString()
@@ -214,7 +214,7 @@ private fun enumValueArguments(
     val expression = defaultValue.expression
     when {
       expression is IrGetEnumValue -> expression.symbol.owner.name
-      expression is IrConst<*> && expression.value == null -> null
+      expression is IrConst && expression.value == null -> null
       else -> unexpectedDefaultValue(parameter)
     }
   }
@@ -249,7 +249,7 @@ private fun IrPluginContext.booleanArguments(
   val defaultValue = parameter.defaultValue?.let { defaultValue ->
     val expression = defaultValue.expression
     when {
-      expression is IrConst<*> -> expression.value
+      expression is IrConst -> expression.value
       else -> unexpectedDefaultValue(parameter)
     }
   }

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
@@ -143,7 +143,6 @@ internal class ClassSpecializer(
         statements += irDelegatingConstructorCall(
           context = pluginContext,
           symbol = superConstructor.symbol,
-          valueArgumentsCount = specialization.arguments.size,
         ) {
           for ((index, argument) in specialization.arguments.withIndex()) {
             putValueArgument(index, argument.expression())
@@ -172,7 +171,6 @@ internal class ClassSpecializer(
         statements += irDelegatingConstructorCall(
           context = pluginContext,
           symbol = superConstructor.symbol,
-          valueArgumentsCount = specialization.arguments.size,
         ) {
           for ((index, argument) in specialization.arguments.withIndex()) {
             putValueArgument(index, argument.expression())

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ir.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ir.kt
@@ -43,6 +43,7 @@ import org.jetbrains.kotlin.ir.expressions.IrInstanceInitializerCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrDelegatingConstructorCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
@@ -141,7 +142,6 @@ fun DeclarationIrBuilder.irDelegatingConstructorCall(
   context: IrGeneratorContext,
   symbol: IrConstructorSymbol,
   typeArgumentsCount: Int = 0,
-  valueArgumentsCount: Int = 0,
   block: IrDelegatingConstructorCall.() -> Unit = {},
 ): IrDelegatingConstructorCall {
   val result = IrDelegatingConstructorCallImpl(
@@ -150,7 +150,6 @@ fun DeclarationIrBuilder.irDelegatingConstructorCall(
     type = context.irBuiltIns.unitType,
     symbol = symbol,
     typeArgumentsCount = typeArgumentsCount,
-    valueArgumentsCount = valueArgumentsCount,
   )
   result.block()
   return result

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 
 [libraries]
 android-gradlePlugin = "com.android.tools.build:gradle:8.7.2"
@@ -8,10 +8,10 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service-compiler = { module = "dev.zacsweers.autoservice:auto-service-ksp", version = "1.2.0" }
 binary-compatibility-validator-gradle-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.16.3" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
-google-ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:2.0.21-1.0.28"
+google-ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:2.1.0-1.0.29"
 junit = { module = "junit:junit", version = "4.13.2" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version = "5.11.3" }
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.6.0" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.7.0" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 mavenPublish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.30.0" }


### PR DESCRIPTION
To ensure burst compatibility with Kotlin 2.1.0, it is necessary to update `dev.zacsweers.kctfork:core`. I have updated it to version `0.7.0`, which was recently released to support this.

Closes: https://github.com/cashapp/burst/issues/72