### PR TITLE
Don't generate a broken test when a constructor has a value class parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/burst/compare/2.3.0...HEAD
 
+**Fixed**
+
+ * Don't fail for constructors that have value class parameters. Unfortunately we can't run such tests from the IDE.
 
 
 ## [2.4.0] *(2025-01-24)*

--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
@@ -329,6 +329,31 @@ class BurstGradlePluginTest {
     }
   }
 
+  @Test
+  fun valueClassConstructor() {
+    val projectDir = File("src/test/projects/valueClassConstructor")
+
+    val taskName = ":lib:test"
+    val result = createRunner(projectDir, "clean", taskName).build()
+    assertThat(result.task(taskName)!!.outcome).isIn(*SUCCESS_OUTCOMES)
+
+    val testResults = projectDir.resolve("lib/build/test-results")
+
+    // There's no default specialization.
+    assertThat(testResults.resolve("test/TEST-CoffeeTest.xml").exists()).isFalse()
+
+    val sampleTest = readTestSuite(testResults.resolve("test/TEST-CoffeeTest_Decaf.xml"))
+    val sampleTestTest = sampleTest.testCases.single()
+    assertThat(sampleTestTest.name).isEqualTo("test")
+    assertThat(sampleTestTest.skipped).isFalse()
+    assertThat(sampleTest.systemOut).isEqualTo(
+      """
+      |running Decaf
+      |
+      """.trimMargin(),
+    )
+  }
+
   private fun createRunner(
     projectDir: File,
     vararg taskNames: String,

--- a/burst-gradle-plugin/src/test/projects/valueClassConstructor/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/valueClassConstructor/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+buildscript {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath("app.cash.burst:burst-gradle-plugin:${project.property("burstVersion")}")
+    classpath(libs.kotlin.gradlePlugin)
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+
+  tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+  }
+
+  tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/valueClassConstructor/lib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/valueClassConstructor/lib/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  kotlin("jvm")
+  id("app.cash.burst")
+}
+
+dependencies {
+  testImplementation(kotlin("test"))
+}

--- a/burst-gradle-plugin/src/test/projects/valueClassConstructor/lib/src/test/kotlin/CoffeeTest.kt
+++ b/burst-gradle-plugin/src/test/projects/valueClassConstructor/lib/src/test/kotlin/CoffeeTest.kt
@@ -1,0 +1,27 @@
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import kotlin.test.Test
+
+@Burst
+class CoffeeTest(
+  private val espresso: Espresso = burstValues(Decaf, Regular, Double),
+) {
+  @Test
+  fun test() {
+    println("running $espresso")
+  }
+}
+
+@JvmInline
+value class Espresso(val ordinal: Int) {
+  override fun toString() = when (this) {
+    Decaf -> "Decaf"
+    Regular -> "Regular"
+    Double -> "Double"
+    else -> "$ordinal"
+  }
+}
+
+val Decaf = Espresso(0)
+val Regular = Espresso(1)
+val Double = Espresso(2)

--- a/burst-gradle-plugin/src/test/projects/valueClassConstructor/settings.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/valueClassConstructor/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":lib")

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/BurstApis.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/BurstApis.kt
@@ -70,5 +70,11 @@ private val junit5TestClassId = junit5Package.classId("Test")
 private val kotlinTestPackage = FqPackageName("kotlin.test")
 private val kotlinTestClassId = kotlinTestPackage.classId("Test")
 
+private val kotlinJvmFqPackage = FqPackageName("kotlin.jvm")
+private val jvmInlineAnnotationId = kotlinJvmFqPackage.classId("JvmInline")
+
 internal val IrAnnotationContainer.hasAtBurst: Boolean
   get() = hasAnnotation(burstAnnotationId)
+
+internal val IrAnnotationContainer.hasAtJvmInline: Boolean
+  get() = hasAnnotation(jvmInlineAnnotationId)


### PR DESCRIPTION
An implementation detail of the Kotlin compiler gets in our way.

Closes: https://github.com/cashapp/burst/issues/93