### PR TITLE
Fix TestInterceptors that span modules

### DIFF
--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+buildscript {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath("app.cash.burst:burst-gradle-plugin:${project.property("burstVersion")}")
+    classpath(libs.kotlin.gradlePlugin)
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+
+  tasks.withType(JavaCompile::class.java).configureEach {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+  }
+
+  tasks.withType(KotlinJvmCompile::class.java).configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  kotlin("jvm")
+  id("app.cash.burst")
+}
+
+dependencies {
+  implementation(project(":testlib"))
+  testImplementation(kotlin("test"))
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/CircleTest.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/CircleTest.kt
@@ -1,0 +1,23 @@
+package app.cash.burst.tests
+
+import app.cash.burst.InterceptTest
+import app.cash.burst.testlib.BasicInterceptor
+import app.cash.burst.testlib.ShapeTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+
+/** This inherits a test function from the superclass. */
+open class CircleTest : ShapeTest() {
+  @InterceptTest
+  val circleInterceptor = BasicInterceptor("circle")
+
+  @BeforeTest
+  fun beforeTestCircle() {
+    println("> before test circle")
+  }
+
+  @AfterTest
+  fun afterTestCircle() {
+    println("< after test circle")
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/settings.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/settings.gradle.kts
@@ -1,0 +1,10 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":lib")
+include(":testlib")

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+  kotlin("jvm")
+  id("app.cash.burst")
+}
+
+dependencies {
+  implementation("app.cash.burst:burst:${project.property("burstVersion")}")
+  implementation(kotlin("test"))
+  implementation(kotlin("test-junit"))
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/BasicInterceptor.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/BasicInterceptor.kt
@@ -1,0 +1,12 @@
+package app.cash.burst.testlib
+
+import app.cash.burst.TestFunction
+import app.cash.burst.TestInterceptor
+
+class BasicInterceptor(val name: String) : TestInterceptor {
+  override fun intercept(testFunction: TestFunction) {
+    println("> intercepting $name")
+    testFunction()
+    println("< intercepted $name")
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/ShapeTest.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/ShapeTest.kt
@@ -1,0 +1,26 @@
+package app.cash.burst.testlib
+
+import app.cash.burst.InterceptTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+open class ShapeTest {
+  @InterceptTest
+  val shapeInterceptor = BasicInterceptor("shape")
+
+  @BeforeTest
+  fun beforeTest() {
+    println("> before test shape")
+  }
+
+  @AfterTest
+  fun afterTest() {
+    println("< after test shape")
+  }
+
+  @Test
+  fun testShape() {
+    println("  running testShape")
+  }
+}

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestInterceptorIrGenerationExtension.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestInterceptorIrGenerationExtension.kt
@@ -36,11 +36,14 @@ class TestInterceptorIrGenerationExtension(
       override fun visitClassNew(declaration: IrClass): IrStatement {
         val classDeclaration = super.visitClassNew(declaration) as IrClass
 
-        val hierarchyInterceptorInjector = HierarchyInterceptorInjector(
-          pluginContext = pluginContext,
-          burstApis = burstApis,
-        )
-        hierarchyInterceptorInjector.apply(classDeclaration)
+        try {
+          HierarchyInterceptorInjector(
+            pluginContext = pluginContext,
+            burstApis = burstApis,
+          ).apply(classDeclaration)
+        } catch (e: BurstCompilationException) {
+          messageCollector.report(e.severity, e.message, currentFile.locationOf(e.element))
+        }
 
         return classDeclaration
       }


### PR DESCRIPTION
We had a bug when @TestInterceptor was applied to a superclass from another module. The compiler plug-in didn't reliabily see the rewritten superclass, so the superclass interceptors were not executed.