### PR TITLE
Fix a bug with private superclass interceptors

### DIFF
--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/TestInterceptorGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/TestInterceptorGradlePluginTest.kt
@@ -131,4 +131,27 @@ class TestInterceptorGradlePluginTest {
       )
     }
   }
+
+  @Test
+  fun abstractClassHasSuperClassThatIntercepts() {
+    val tester = GradleTester("interceptorAcrossModules")
+    tester.cleanAndBuild(":lib:test")
+
+    with(tester.readTestSuite("app.cash.burst.tests.BottomTest")) {
+      assertThat(systemOut).isEqualTo(
+        """
+        |> intercepting top
+        |  running bottom
+        |< intercepted top
+        |> intercepting top
+        |  running middle
+        |< intercepted top
+        |> intercepting top
+        |  running top
+        |< intercepted top
+        |
+        """.trimMargin(),
+      )
+    }
+  }
 }

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/BottomTest.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/BottomTest.kt
@@ -1,0 +1,10 @@
+package app.cash.burst.tests
+
+import kotlin.test.Test
+
+class BottomTest : MiddleTest() {
+  @Test
+  fun testBottom() {
+    println("  running bottom")
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/MiddleTest.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/lib/src/test/kotlin/app/cash/burst/tests/MiddleTest.kt
@@ -1,0 +1,11 @@
+package app.cash.burst.tests
+
+import app.cash.burst.testlib.TopTest
+import kotlin.test.Test
+
+abstract class MiddleTest : TopTest() {
+  @Test
+  fun testMiddle() {
+    println("  running middle")
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/TopTest.kt
+++ b/burst-gradle-plugin/src/test/projects/interceptorAcrossModules/testlib/src/main/kotlin/app/cash/burst/testlib/TopTest.kt
@@ -1,0 +1,14 @@
+package app.cash.burst.testlib
+
+import app.cash.burst.InterceptTest
+import kotlin.test.Test
+
+abstract class TopTest {
+  @InterceptTest
+  private val interceptor = BasicInterceptor("top")
+
+  @Test
+  fun testTop() {
+    println("  running top")
+  }
+}


### PR DESCRIPTION
We weren't publishing our added functions in class metadata, and that was causing private @InterceptTest properties to be missed.

Adding it was made complicated by the fact that we started getting fake overrides, that we now need to remove.