### PR TITLE
Support coroutine tests in Burst

### DIFF
--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
@@ -17,6 +17,7 @@
 package app.cash.burst.gradle
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -69,13 +70,29 @@ class BurstGradlePluginTest {
     // Each test class is executed normally with nothing skipped.
     with(tester.readTestSuite("CoffeeTest_Regular", testTaskName)) {
       assertThat(testCases.map { it.name }).containsExactlyInAnyOrder(
-        "test_Milk[$platformName]",
-        "test_None[$platformName]",
-        "test_Oat[$platformName]",
+        "basicTest_Milk[$platformName]",
+        "basicTest_None[$platformName]",
+        "basicTest_Oat[$platformName]",
+        "coroutinesTest_Milk[$platformName]",
+        "coroutinesTest_None[$platformName]",
+        "coroutinesTest_Oat[$platformName]",
       )
 
-      val sampleSpecialization = testCases.single { it.name == "test_Milk[$platformName]" }
+      val sampleSpecialization = testCases.single { it.name == "basicTest_Milk[$platformName]" }
       assertThat(sampleSpecialization.skipped).isFalse()
+
+      assertThat(systemOut).contains(
+        """
+        |set up Regular
+        |running Regular Oat in coffeeCoroutine
+        |
+        """.trimMargin(),
+        """
+        |set up Regular
+        |running Regular Oat
+        |
+        """.trimMargin(),
+      )
     }
 
     if (checkKlibMetadata) {
@@ -86,10 +103,14 @@ class BurstGradlePluginTest {
       val coffeeTestMetadata = klibMetadata.classes.first { it.name == "CoffeeTest" }
       assertThat(coffeeTestMetadata.functions.map { it.name }).containsExactlyInAnyOrder(
         "setUp",
-        "test",
-        "test_Milk",
-        "test_None",
-        "test_Oat",
+        "basicTest",
+        "basicTest_Milk",
+        "basicTest_None",
+        "basicTest_Oat",
+        "coroutinesTest",
+        "coroutinesTest_Milk",
+        "coroutinesTest_None",
+        "coroutinesTest_Oat",
       )
     }
   }

--- a/burst-gradle-plugin/src/test/projects/multiplatform/lib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/multiplatform/lib/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     commonTest {
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.kotlinx.coroutines.core)
+        implementation(libs.kotlinx.coroutines.test)
       }
     }
   }

--- a/burst-gradle-plugin/src/test/projects/multiplatform/lib/src/commonTest/kotlin/CoffeeTest.kt
+++ b/burst-gradle-plugin/src/test/projects/multiplatform/lib/src/commonTest/kotlin/CoffeeTest.kt
@@ -1,6 +1,12 @@
 import app.cash.burst.Burst
+import kotlin.coroutines.coroutineContext
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
 
 @Burst
 class CoffeeTest(
@@ -12,8 +18,17 @@ class CoffeeTest(
   }
 
   @Test
-  fun test(dairy: Dairy) {
+  fun basicTest(dairy: Dairy) {
     println("running $espresso $dairy")
+  }
+
+  @Test
+  fun coroutinesTest(dairy: Dairy) = runTest(CoroutineName("coffeeCoroutine")) {
+    val deferred = async {
+      println("running $espresso $dairy in ${coroutineContext[CoroutineName]?.name}")
+    }
+    delay(1000.milliseconds)
+    deferred.await()
   }
 }
 

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/Argument.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/Argument.kt
@@ -43,9 +43,6 @@ internal sealed interface Argument {
   /** True if this argument matches the default parameter value. */
   val isDefault: Boolean
 
-  /** Where to assign this argument to in a call. */
-  val indexInParameters: Int
-
   /** A string that's safe to use in a declaration name. */
   val name: String
 
@@ -64,9 +61,6 @@ private class EnumValueArgument(
 ) : Argument {
   override val name = value.name.identifier
 
-  override val indexInParameters: Int
-    get() = original.indexInParameters
-
   override fun expression() =
     IrGetEnumValueImpl(original.startOffset, original.endOffset, type, value.symbol)
 
@@ -83,9 +77,6 @@ private class BooleanArgument(
 ) : Argument {
   override val name = value.toString()
 
-  override val indexInParameters: Int
-    get() = original.indexInParameters
-
   override fun expression() =
     IrConstImpl.boolean(original.startOffset, original.endOffset, booleanType, value)
 
@@ -101,9 +92,6 @@ private class NullArgument(
 ) : Argument {
   override val name = "null"
 
-  override val indexInParameters: Int
-    get() = original.indexInParameters
-
   override fun expression() = IrConstImpl.constNull(original.startOffset, original.endOffset, type)
 
   override fun <R, D> accept(visitor: IrVisitor<R, D>, data: D): R {
@@ -118,8 +106,6 @@ private class BurstValuesArgument(
   index: Int,
 ) : Argument {
   override val isDefault = index == 0
-  override val indexInParameters: Int
-    get() = parameter.indexInParameters
   override val name = value.suggestedName() ?: index.toString()
 
   override fun expression() = value.deepCopyWithSymbols(parameter.parent)

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
@@ -148,8 +148,9 @@ internal class ClassSpecializer(
           context = pluginContext,
           symbol = superConstructor.symbol,
         ) {
+          arguments.clear()
           for (argument in specialization.arguments) {
-            arguments[argument.indexInParameters] = argument.expression()
+            arguments += argument.expression()
           }
         }
         statements += irInstanceInitializerCall(
@@ -176,8 +177,9 @@ internal class ClassSpecializer(
           context = pluginContext,
           symbol = superConstructor.symbol,
         ) {
+          arguments.clear()
           for (argument in specialization.arguments) {
-            arguments[argument.indexInParameters] = argument.expression()
+            arguments += argument.expression()
           }
         }
       }

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestFunction.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestFunction.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.burst.kotlin
+
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.visitors.IrTransformer
+
+/** A function annotated `@Test`. */
+sealed interface TestFunction {
+  val function: IrSimpleFunction
+  val testAnnotation: IrClassSymbol
+
+  /** A test that calls `runTest()` in its body. */
+  data class Suspending(
+    override val function: IrSimpleFunction,
+    override val testAnnotation: IrClassSymbol,
+    val runTestCall: IrCall,
+  ) : TestFunction
+
+  /** A test that does not call `runTest()`. */
+  data class NonSuspending(
+    override val function: IrSimpleFunction,
+    override val testAnnotation: IrClassSymbol,
+  ) : TestFunction
+
+  /** Drop `@Test` from this function's annotations. */
+  fun dropAtTest() {
+    function.annotations = function.annotations.filter {
+      it.type.classOrNull != testAnnotation
+    }
+  }
+}
+
+internal class TestFunctionReader(
+  val burstApis: BurstApis,
+) {
+  /** Returns non-null if [function] is annotated `@Test`. */
+  fun readOrNull(function: IrSimpleFunction): TestFunction? {
+    val testAnnotation = burstApis.findTestAnnotation(function) ?: return null
+    var runTestCall: IrCall? = null
+
+    function.body?.transform(
+      object : IrTransformer<Unit>() {
+        override fun visitCall(
+          expression: IrCall,
+          data: Unit,
+        ): IrElement {
+          if (runTestCall == null && burstApis.isRunTest(expression)) {
+            runTestCall = expression
+          }
+          return super.visitCall(expression, data)
+        }
+      },
+      Unit,
+    )
+
+    return when {
+      runTestCall != null -> TestFunction.Suspending(function, testAnnotation, runTestCall)
+      else -> TestFunction.NonSuspending(function, testAnnotation)
+    }
+  }
+}

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestInterceptorsValidator.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestInterceptorsValidator.kt
@@ -65,7 +65,7 @@ internal class TestInterceptorsValidator(
         )
       }
 
-      if (usesTestInterceptor && function is TestInterceptorsInput.Function.Suspending) {
+      if (usesTestInterceptor && function is TestFunction.Suspending) {
         val testInterceptor = input.testInterceptors.firstOrNull()
         throw BurstCompilationException(
           "${testInterceptor?.nameForError ?: "TestInterceptor"} cannot intercept a coroutine test function",
@@ -73,7 +73,7 @@ internal class TestInterceptorsValidator(
         )
       }
 
-      if (usesCoroutineTestInterceptor && function is TestInterceptorsInput.Function.NonSuspending) {
+      if (usesCoroutineTestInterceptor && function is TestFunction.NonSuspending) {
         val testInterceptor = input.coroutineTestInterceptors.firstOrNull()
         throw BurstCompilationException(
           "${testInterceptor?.nameForError ?: "CoroutineTestInterceptor"} cannot intercept a non-coroutine test function",


### PR DESCRIPTION
We were previously broken with @Burst tests that
called runTest, when executing on Kotlin/JS.