### PR TITLE
Kotlin 2.3.0-RC.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.0-Beta2"
+kotlin = "2.3.0-RC"
 kotlinx-coroutines = "1.10.2"
 
 [libraries]
@@ -9,7 +9,7 @@ assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 binary-compatibility-validator-gradle-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.18.1" }
 junit = { module = "junit:junit", version = "4.13.2" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version = "5.14.1" }
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.11.1" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.12.0-alpha01" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }


### PR DESCRIPTION
Only had to update kotlin compile testing to fix tests. `2.11.0-beta1` still works with Kotlin `2.3.0-RC` so no release needed.