### PR TITLE
Support `TestScope.runTest` extension for coroutine tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 * Pass annotation instances to interceptors
 
+**Fixed**
+
+* Support `TestScope.runTest` extension function for `CoroutineTestInterceptor`.
+
 ## [2.12.0-beta1] *(2026-01-12)*
 [2.12.0-beta1]: https://github.com/cashapp/burst/releases/tag/2.12.0-beta1
 

--- a/burst-kotlin-plugin-tests/src/test/kotlin/app/cash/burst/kotlin/SuspendingTestInterceptorKotlinPluginTest.kt
+++ b/burst-kotlin-plugin-tests/src/test/kotlin/app/cash/burst/kotlin/SuspendingTestInterceptorKotlinPluginTest.kt
@@ -168,6 +168,61 @@ class SuspendingTestInterceptorKotlinPluginTest {
   }
 
   @Test
+  fun useTestScopeFromReceiverInInterceptor() {
+    val log =
+      BurstTester(packageName = "com.example")
+        .compileAndRun(
+          SourceFile.kotlin(
+            "Main.kt",
+            """
+        package com.example
+
+        import app.cash.burst.InterceptTest
+        import app.cash.burst.coroutines.CoroutineTestFunction
+        import app.cash.burst.coroutines.CoroutineTestInterceptor
+        import kotlin.coroutines.coroutineContext
+        import kotlin.test.Test
+        import kotlinx.coroutines.CoroutineName
+        import kotlinx.coroutines.test.runTest
+        import kotlinx.coroutines.test.TestScope
+        import kotlin.time.Duration.Companion.seconds
+
+        class SampleTest {
+          @InterceptTest
+          val interceptor = object : CoroutineTestInterceptor {
+            override suspend fun intercept(testFunction: CoroutineTestFunction) {
+              log("intercepting ${'$'}testFunction in ${'$'}{coroutineContext[CoroutineName]?.name}")
+              log("advancing time in interceptor")
+              testFunction.scope.testScheduler.advanceTimeBy(1.seconds)
+              testFunction()
+            }
+          }
+
+          val testScope = TestScope(CoroutineName("fancyScope"))
+
+          @Test
+          fun happyPath() = testScope.runTest {
+            log("advancing time in test")
+            testScheduler.advanceTimeBy(1.seconds)
+          }
+        }
+
+        fun main(vararg args: String) {
+          SampleTest().happyPath()
+        }
+        """,
+          )
+        )
+
+    assertThat(log)
+      .containsExactly(
+        "intercepting com.example.SampleTest.happyPath in fancyScope",
+        "advancing time in interceptor",
+        "advancing time in test",
+      )
+  }
+
+  @Test
   fun cannotUseNonCoroutineTestInterceptorWithCoroutineTestInterceptor() {
     val result =
       compile(

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/InterceptorInjector.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/InterceptorInjector.kt
@@ -498,6 +498,7 @@ internal class InterceptorInjector(
           interceptTestBodyExpression(
             testFunction = original,
             testBodyLambda = runTestCall.arguments[runTestCall.arguments.size - 1]!!,
+            runTestCall = runTestCall,
           )
       }
 
@@ -520,6 +521,7 @@ internal class InterceptorInjector(
   private fun interceptTestBodyExpression(
     testFunction: IrSimpleFunction,
     testBodyLambda: IrExpression,
+    runTestCall: IrCall,
   ): IrFunctionExpression {
     // Create a lambda for the new test body. The new lambda's body creates a `TestFunction` that
     // delegates to the original test body.
@@ -527,6 +529,7 @@ internal class InterceptorInjector(
       context = pluginContext,
       burstApis = burstApis,
       original = originalParent,
+      runTestSymbol = runTestCall.symbol,
     ) { testScope ->
       +callInterceptWithTestBody(original = testFunction, testScope = irGet(testScope)) {
         irFunctionBody(context = context) {

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestFunction.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/TestFunction.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 
@@ -31,6 +32,7 @@ sealed interface TestFunction {
   data class Suspending(
     override val function: IrSimpleFunction,
     override val testAnnotation: IrClassSymbol,
+    val runTestVariant: IrFunctionSymbol,
     val runTestCall: IrCall,
   ) : TestFunction
 
@@ -53,7 +55,8 @@ internal class TestFunctionReader(val burstApis: BurstApis) {
     val runTestCall = readRunTestCall(function)
 
     return when {
-      runTestCall != null -> TestFunction.Suspending(function, testAnnotation, runTestCall)
+      runTestCall != null ->
+        TestFunction.Suspending(function, testAnnotation, runTestCall.symbol, runTestCall)
       else -> TestFunction.NonSuspending(function, testAnnotation)
     }
   }

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ir.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ir.kt
@@ -69,6 +69,7 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
+import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.symbols.impl.IrSimpleFunctionSymbolImpl
 import org.jetbrains.kotlin.ir.types.starProjectedType
@@ -212,6 +213,7 @@ internal fun irTestBodyLambda(
   context: IrPluginContext,
   burstApis: BurstApis,
   original: IrElement,
+  runTestSymbol: IrFunctionSymbol,
   blockBody: IrBlockBodyBuilder.(testScope: IrValueParameter) -> Unit,
 ): IrFunctionExpression {
   val function =
@@ -234,7 +236,7 @@ internal fun irTestBodyLambda(
   return IrFunctionExpressionImpl(
     startOffset = original.startOffset,
     endOffset = original.endOffset,
-    type = burstApis.runTestSymbol!!.owner.parameters.last().type,
+    type = runTestSymbol.owner.parameters.last().type,
     function = function,
     origin = IrStatementOrigin.Companion.LAMBDA,
   )


### PR DESCRIPTION
Fixes https://github.com/cashapp/burst/issues/268