### PR TITLE
Annotations, e.g. `@Ignore`, on functions and classes are correctly propagated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Added**
 
 * Support Kotlin 2.4.0-Beta1.
+* Annotations, e.g. `@Ignore`, on functions and classes are correctly propagated.
 
 
 ## [2.13.0-beta1]

--- a/burst-kotlin-plugin-tests/src/test/data/dump/ir/IgnoreAnnotation.fir.kt.txt
+++ b/burst-kotlin-plugin-tests/src/test/data/dump/ir/IgnoreAnnotation.fir.kt.txt
@@ -1,0 +1,118 @@
+@Burst
+@Disabled
+abstract class Coffee2Test {
+  private val espresso: Espresso
+    field = espresso
+    private get
+
+  val log: MutableList<String>
+    field = mutableListOf<String>()
+    get
+
+  protected constructor(espresso: Espresso) /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  @Test
+  fun test() {
+    plusAssign<String>(/* <this> = <this>.<get-log>(), */ element = "running " + <this>.<get-espresso>())
+  }
+
+}
+
+@Disabled
+class Coffee2Test_Decaf : Coffee2Test {
+  constructor() /* primary */ {
+    super/*Coffee2Test*/(espresso = Espresso.Decaf)
+    /* <init>() */
+
+  }
+
+}
+
+@Disabled
+class Coffee2Test_Double : Coffee2Test {
+  constructor() /* primary */ {
+    super/*Coffee2Test*/(espresso = Espresso.Double)
+    /* <init>() */
+
+  }
+
+}
+
+@Disabled
+class Coffee2Test_Regular : Coffee2Test {
+  constructor() /* primary */ {
+    super/*Coffee2Test*/(espresso = Espresso.Regular)
+    /* <init>() */
+
+  }
+
+}
+
+@Burst
+class CoffeeTest {
+  val log: MutableList<String>
+    field = mutableListOf<String>()
+    get
+
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  @Disabled
+  fun test(espresso: Espresso) {
+    plusAssign<String>(/* <this> = <this>.<get-log>(), */ element = "running " + espresso)
+  }
+
+  @Test
+  @Disabled
+  fun test_Decaf() {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Decaf: Espresso = Espresso.Decaf
+    tmp0_receiver.test(espresso = tmp1_Decaf)
+  }
+
+  @Test
+  @Disabled
+  fun test_Double() {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Double: Espresso = Espresso.Double
+    tmp0_receiver.test(espresso = tmp1_Double)
+  }
+
+  @Test
+  @Disabled
+  fun test_Regular() {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Regular: Espresso = Espresso.Regular
+    tmp0_receiver.test(espresso = tmp1_Regular)
+  }
+
+}
+
+enum class Espresso : Enum<Espresso> {
+  Decaf = Espresso()
+
+  Regular = Espresso()
+
+  Double = Espresso()
+
+  private constructor() /* primary */ {
+    super/*Enum*/<Espresso>()
+    /* <init>() */
+
+  }
+
+  /* static */ fun valueOf(value: String): Espresso /* Synthetic body for ENUM_VALUEOF */
+
+  /* static */ fun values(): Array<Espresso> /* Synthetic body for ENUM_VALUES */
+
+  /* static */ val entries: EnumEntries<Espresso>
+    get(): EnumEntries<Espresso> /* Synthetic body for ENUM_ENTRIES */
+
+}

--- a/burst-kotlin-plugin-tests/src/test/data/dump/ir/IgnoreAnnotation.kt
+++ b/burst-kotlin-plugin-tests/src/test/data/dump/ir/IgnoreAnnotation.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.burst.Burst
+import kotlin.test.Ignore
+import kotlin.test.Test
+
+@Burst
+class CoffeeTest {
+  val log = mutableListOf<String>()
+
+  @Test
+  @Ignore
+  fun test(espresso: Espresso) {
+    log += "running $espresso"
+  }
+}
+
+@Burst
+@Ignore
+class Coffee2Test(private val espresso: Espresso) {
+  val log = mutableListOf<String>()
+
+  @Test
+  fun test() {
+    log += "running ${espresso}"
+  }
+}
+
+enum class Espresso {
+  Decaf,
+  Regular,
+  Double,
+}

--- a/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/IrDumpTestGenerated.java
+++ b/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/IrDumpTestGenerated.java
@@ -51,6 +51,12 @@ public class IrDumpTestGenerated extends AbstractIrDumpTest {
     }
 
     @Test
+    @TestMetadata("IgnoreAnnotation.kt")
+    public void testIgnoreAnnotation() {
+      run("IgnoreAnnotation.kt");
+    }
+
+    @Test
     @TestMetadata("TestInterceptor.kt")
     public void testTestInterceptor() {
       run("TestInterceptor.kt");

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
@@ -26,10 +26,12 @@ import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrTypeSystemContextImpl
+import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.util.addFakeOverrides
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
+import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.Name
 
@@ -139,6 +141,12 @@ internal class ClassSpecializer(
           superTypes = listOf(original.defaultType)
           createThisReceiverParameter()
         }
+
+    val burstFqName = BurstApis.burstAnnotationId.asSingleFqName()
+    created.annotations +=
+      original.annotations
+        .filter { it.type.classFqName != burstFqName }
+        .map { it.deepCopyWithSymbols() }
 
     created
       .addConstructor { initDefaults(original) }

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/FunctionSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/FunctionSpecializer.kt
@@ -209,6 +209,7 @@ internal class FunctionSpecializer(
         }
 
     result.annotations += original.testAnnotation.asAnnotation()
+    result.annotations += original.function.annotations.map { it.deepCopyWithSymbols() }
 
     result.irFunctionBody(context = pluginContext) {
       val receiverLocal =


### PR DESCRIPTION
Fixes #318