### PR TITLE
Add Burst runtime to test fixtures

### DIFF
--- a/burst-gradle-plugin/src/main/kotlin/app/cash/burst/gradle/BurstPlugin.kt
+++ b/burst-gradle-plugin/src/main/kotlin/app/cash/burst/gradle/BurstPlugin.kt
@@ -49,6 +49,12 @@ class BurstPlugin : Plugin<Project> {
       target.dependencies { add("testImplementation", "app.cash.burst:burst:$burstVersion") }
     }
 
+    target.pluginManager.withPlugin("org.gradle.java-test-fixtures") {
+      target.dependencies {
+        add("testFixturesImplementation", "app.cash.burst:burst:$burstVersion")
+      }
+    }
+
     target.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
       applied = true
       target.pluginManager.apply(BurstKotlinPlugin::class.java)

--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
@@ -34,6 +34,12 @@ class BurstGradlePluginTest {
   }
 
   @Test
+  fun testFixtures() {
+    val tester = GradleTester("testFixtures")
+    tester.cleanAndBuild(":lib:testFixturesClasses")
+  }
+
+  @Test
   fun multiplatformJvm() {
     multiplatform(testTaskName = "jvmTest", platformName = "jvm")
   }

--- a/burst-gradle-plugin/src/test/projects/testFixtures/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/testFixtures/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+buildscript {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath("app.cash.burst:burst-gradle-plugin:${project.property("burstVersion")}")
+    classpath(libs.kotlin.gradlePlugin)
+  }
+}
+
+allprojects {
+  repositories {
+    maven {
+      url = file("$rootDir/../../../../../build/testMaven").toURI()
+    }
+    mavenCentral()
+    google()
+  }
+
+  tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+  }
+
+  tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_1_8)
+    }
+  }
+}

--- a/burst-gradle-plugin/src/test/projects/testFixtures/lib/build.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/testFixtures/lib/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+  `java-test-fixtures`
+  kotlin("jvm")
+  id("app.cash.burst")
+}

--- a/burst-gradle-plugin/src/test/projects/testFixtures/lib/src/testFixtures/kotlin/BurstFixture.kt
+++ b/burst-gradle-plugin/src/test/projects/testFixtures/lib/src/testFixtures/kotlin/BurstFixture.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.burst.Burst
+
+class BurstFixture {
+  val annotation = Burst::class
+}

--- a/burst-gradle-plugin/src/test/projects/testFixtures/settings.gradle.kts
+++ b/burst-gradle-plugin/src/test/projects/testFixtures/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../../../../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":lib")


### PR DESCRIPTION
Fixes #111

## Summary

- Add the Burst runtime to `testFixturesImplementation` when Java test fixtures are enabled.
- Add focused TestKit coverage that compiles a Burst reference from the test-fixtures source set.

## Validation

- `./gradlew :burst-gradle-plugin:test --tests app.cash.burst.gradle.BurstGradlePluginTest.testFixtures`
- `./gradlew spotlessCheck`
- `git diff --check`
