### PR TITLE
Warn for single-value burstValues calls

### DIFF
--- a/burst-kotlin-plugin-tests/src/test/data/diagnostic/BurstValuesJustOne.fir.diag.txt
+++ b/burst-kotlin-plugin-tests/src/test/data/diagnostic/BurstValuesJustOne.fir.diag.txt
@@ -1,0 +1,1 @@
+/BurstValuesJustOne.kt:(775,790): warning: burstValues() should have more than one argument

--- a/burst-kotlin-plugin-tests/src/test/data/diagnostic/BurstValuesJustOne.kt
+++ b/burst-kotlin-plugin-tests/src/test/data/diagnostic/BurstValuesJustOne.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// RENDER_DIAGNOSTICS_FULL_TEXT
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import kotlin.test.Test
+
+@Burst
+class CoffeeTest {
+  @Test
+  fun test(volume: Int = <!BURST_VALUES_WITH_SINGLE_ARGUMENT!>burstValues(12)<!>) {
+  }
+}

--- a/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/DiagnosticTestGenerated.java
+++ b/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/DiagnosticTestGenerated.java
@@ -25,6 +25,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   }
 
   @Test
+  @TestMetadata("BurstValuesJustOne.kt")
+  public void testBurstValuesJustOne() {
+    run("BurstValuesJustOne.kt");
+  }
+
+  @Test
   @TestMetadata("BurstValuesReferencesEarlierParameter.kt")
   public void testBurstValuesReferencesEarlierParameter() {
     run("BurstValuesReferencesEarlierParameter.kt");

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/diagnostic/ArgumentChecker.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/diagnostic/ArgumentChecker.kt
@@ -87,7 +87,16 @@ context(context: CheckerContext, reporter: DiagnosticReporter)
 private fun checkParam(declaration: FirValueParameter) {
   declaration.defaultValue?.let { defaultValue ->
     val defaultCall = defaultValue.toResolvedCallableSymbol(context.session)
-    if (defaultCall?.callableId == BurstApis.burstValuesId) return
+    if (defaultCall?.callableId == BurstApis.burstValuesId) {
+      val call = defaultValue as? FirFunctionCall
+      if (call?.flattenedArguments()?.size == 1) {
+        reporter.reportOn(
+          declaration.source,
+          BurstDiagnostics.BURST_VALUES_WITH_SINGLE_ARGUMENT,
+        )
+      }
+      return
+    }
 
     // Check the default value if it isn't a burstValues() call
     val isConst = defaultValue.hasConstantValue(context.session)
@@ -112,19 +121,19 @@ private fun checkBurstValuesReferences(
 ) {
   val call = declaration.defaultValue as? FirFunctionCall ?: return
 
-  val flattenedArgs =
-    call.arguments.flatMap {
-      when (it) {
-        is FirVarargArgumentsExpression -> it.arguments
-        else -> listOf(it)
-      }
-    }
-  for (arg in flattenedArgs) {
+  for (arg in call.flattenedArguments()) {
     arg.accept(
       ArgumentReferenceChecker(otherParameters) {
         reporter.reportOn(it, BurstDiagnostics.PARAMETER_REFERENCE_NOT_ALLOWED)
       }
     )
+  }
+}
+
+private fun FirFunctionCall.flattenedArguments() = arguments.flatMap {
+  when (it) {
+    is FirVarargArgumentsExpression -> it.arguments
+    else -> listOf(it)
   }
 }
 

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/diagnostic/BurstDiagnostics.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/diagnostic/BurstDiagnostics.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies.NAME_
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies.PARAMETER_DEFAULT_VALUE
 import org.jetbrains.kotlin.diagnostics.error0
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
+import org.jetbrains.kotlin.diagnostics.warning0
 import org.jetbrains.kotlin.psi.KtElement
 
 object BurstDiagnostics : KtDiagnosticsContainer() {
@@ -29,6 +30,8 @@ object BurstDiagnostics : KtDiagnosticsContainer() {
   val INVALID_DEFAULT_VALUE by error0<KtElement>(PARAMETER_DEFAULT_VALUE)
 
   val PARAMETER_REFERENCE_NOT_ALLOWED by error0<KtElement>(NAME_IDENTIFIER)
+
+  val BURST_VALUES_WITH_SINGLE_ARGUMENT by warning0<KtElement>(PARAMETER_DEFAULT_VALUE)
 
   override fun getRendererFactory(): BaseDiagnosticRendererFactory {
     return BurstErrorMessages
@@ -50,6 +53,11 @@ object BurstDiagnostics : KtDiagnosticsContainer() {
         map.put(
           PARAMETER_REFERENCE_NOT_ALLOWED,
           "@Burst parameter may not reference other parameters",
+        )
+
+        map.put(
+          BURST_VALUES_WITH_SINGLE_ARGUMENT,
+          "burstValues() should have more than one argument",
         )
       }
   }


### PR DESCRIPTION
Closes #55

## Summary

- Warn when `burstValues()` supplies only one value.
- Reuse flattened FIR arguments so regular and vararg values are counted consistently.
- Add focused diagnostic coverage while preserving the existing no-crash box regression.

## Validation

- `./gradlew :burst-kotlin-plugin-tests:generateTests`
- `./gradlew --no-parallel --max-workers=1 :burst-kotlin-plugin-tests:test --tests app.cash.burst.kotlin.DiagnosticTestGenerated --tests app.cash.burst.kotlin.BoxTestGenerated.testBurstValuesJustOne`
- `./gradlew spotlessCheck`
- `git diff --check`
