### PR TITLE
Patch declaration parents in ClassSpecializer

### DIFF
--- a/burst-kotlin-plugin-tests/src/test/data/box/arguments/BurstValuesWithInlineFunctionsInConstructor.kt
+++ b/burst-kotlin-plugin-tests/src/test/data/box/arguments/BurstValuesWithInlineFunctionsInConstructor.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.burst.Burst
+import app.cash.burst.burstValues
+import kotlin.test.Test
+
+@Burst
+class CoffeeTest(
+  private val greeting: () -> String = burstValues({ "Hello" }, { "Yo" }, { "Hi" }),
+) {
+  val log = mutableListOf<String>()
+
+  @Test
+  fun test() {
+    log += greeting()
+  }
+}
+
+// Confirm that inline function declarations in a constructor are assigned parents.
+// https://github.com/cashapp/burst/issues/284
+fun box(): String {
+  val default = loadClassInstance<CoffeeTest>("CoffeeTest").apply { test() }
+  assertThat(default.log).containsExactly("Hello")
+
+  val yo = loadClassInstance<CoffeeTest>("CoffeeTest_1").apply { test() }
+  assertThat(yo.log).containsExactly("Yo")
+
+  val hi = loadClassInstance<CoffeeTest>("CoffeeTest_2").apply { test() }
+  assertThat(hi.log).containsExactly("Hi")
+
+  return "OK"
+}

--- a/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/BoxTestGenerated.java
+++ b/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/BoxTestGenerated.java
@@ -87,6 +87,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("BurstValuesWithInlineFunctionsInConstructor.kt")
+    public void testBurstValuesWithInlineFunctionsInConstructor() {
+      run("BurstValuesWithInlineFunctionsInConstructor.kt");
+    }
+
+    @Test
     @TestMetadata("BurstValuesWithNameCollisions.kt")
     public void testBurstValuesWithNameCollisions() {
       run("BurstValuesWithNameCollisions.kt");

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/ClassSpecializer.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -162,6 +163,9 @@ internal class ClassSpecializer(
           statements +=
             irInstanceInitializerCall(context = pluginContext, classSymbol = created.symbol)
         }
+        // The argument expressions are deep copies that still point at the original constructor.
+        // Adopt any declarations they contain, like lambdas, into this constructor.
+        patchDeclarationParents()
       }
 
     originalParent.addDeclaration(created)
@@ -191,6 +195,9 @@ internal class ClassSpecializer(
                 }
               }
           }
+          // The argument expressions are deep copies that still point at the original constructor.
+          // Adopt any declarations they contain, like lambdas, into this constructor.
+          patchDeclarationParents()
         }
     pluginContext.metadataDeclarationRegistrar.registerConstructorAsMetadataVisible(constructor)
   }


### PR DESCRIPTION
Fixes #284.

### Problem

`@Burst` on a class whose constructor parameter defaults to `burstValues(...)` containing **lambdas** fails to compile:

```
Platform declaration clash: The following declarations have the same JVM signature
(access$ExampleUnitTest$_init_$lambda$0()Lkotlin/Unit;)
```

### Cause

`BurstValuesArgument.expression()` deep-copies each value with `parameter.parent` as the new parent, which for a constructor parameter is the *original* constructor:

https://github.com/cashapp/burst/blob/trunk/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/Argument.kt#L112

`ClassSpecializer` then inserts those copies into the generated subclass constructors and the generated no-args constructor, but never repairs parents afterward. `FunctionSpecializer` does call `patchDeclarationParents()` on its generated functions, which is why the same `burstValues` with lambdas works fine on a *function* parameter and only breaks on a *constructor* parameter.

The result is that every copied lambda's local `IrSimpleFunction` still claims `TestClass.<init>` as its parent, so lowering mints the same synthetic accessor name once per specialization.

### Why it appeared in 2.11.0

The bug is latent, not new. Between `2.10.2` and `2.11.0`, `ClassSpecializer.kt` is unchanged and the `Argument.kt` diff is only an import move plus formatting. The one substantive change is `kotlin = "2.2.20"` → `"2.3.0"`; Kotlin 2.3's lambda naming stopped tolerating the wrong parent.

On current trunk (Kotlin 2.4.10) the IR validator catches it one phase earlier, so the same test data fails with:

```
error: the compiler plugin 'app.cash.burst.kotlin.BurstIrGenerationExtension' generated invalid IR.
Declaration with wrong parent:
```

emitted three times — matching two generated subclasses plus the no-args constructor for a three-value `burstValues`.

### Fix

Call `patchDeclarationParents()` on both generated constructors, mirroring what `FunctionSpecializer` already does. Per-copy name disambiguation would be the wrong layer: the IR is structurally invalid, and repairing parents lets Kotlin's existing local-declaration naming do the right thing.

### Test

New box test `BurstValuesWithInlineFunctionsInConstructor.kt`, the constructor-parameter counterpart to the existing `BurstValuesWithInlineFunctions.kt`. It fails on unpatched trunk with the IR validation error above and passes with the fix. Full `:burst-kotlin-plugin-tests:test` suite is green.

It uses `loadClassInstance<CoffeeTest>("CoffeeTest")` rather than `CoffeeTest()` for the default specialization, since `box()` is compiled in the same unit and the frontend binds the call to the default argument that the plugin later strips.

### Not verified

I reproduced this on trunk's Kotlin 2.4.10, not on the reporter's exact 2.3.0 + AGP 9 setup, and I did not run the attached `BurstLambdas` sample against a patched build.
