### PR TITLE
Return the delegate's result from non-suspending specializations [CLF-454]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/burst/compare/2.13.0...HEAD
 
-Nothing yet!
+**Fixed**
+
+* Generated specializations of a parameterized `@Test` function now return the original function's
+  result when its return type is not `Unit`. Previously the result was discarded, so a test that
+  returned `TestResult` from a helper that calls `runTest()` completed immediately on Kotlin/JS
+  without awaiting its body, or crashed with a `ClassCastException` in the presence of an
+  `@AfterTest` function.
 
 
 ## [2.13.0]

--- a/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
+++ b/burst-gradle-plugin/src/test/kotlin/app/cash/burst/gradle/BurstGradlePluginTest.kt
@@ -77,6 +77,9 @@ class BurstGradlePluginTest {
           "coroutinesTest_Milk[$platformName]",
           "coroutinesTest_None[$platformName]",
           "coroutinesTest_Oat[$platformName]",
+          "coroutinesInHelperTest_Milk[$platformName]",
+          "coroutinesInHelperTest_None[$platformName]",
+          "coroutinesInHelperTest_Oat[$platformName]",
         )
 
       val sampleSpecialization = testCases.single { it.name == "basicTest_Milk[$platformName]" }
@@ -94,6 +97,12 @@ class BurstGradlePluginTest {
           |running Regular Oat
           |"""
             .trimMargin(),
+          """
+          |set up Regular
+          |running Regular Oat in helper
+          |tear down Regular
+          |"""
+            .trimMargin(),
         )
     }
 
@@ -108,6 +117,7 @@ class BurstGradlePluginTest {
       assertThat(coffeeTestMetadata.functions.map { it.name })
         .containsExactlyInAnyOrder(
           "setUp",
+          "tearDown",
           "basicTest",
           "basicTest_Milk",
           "basicTest_None",
@@ -116,6 +126,10 @@ class BurstGradlePluginTest {
           "coroutinesTest_Milk",
           "coroutinesTest_None",
           "coroutinesTest_Oat",
+          "coroutinesInHelperTest",
+          "coroutinesInHelperTest_Milk",
+          "coroutinesInHelperTest_None",
+          "coroutinesInHelperTest_Oat",
         )
     }
   }

--- a/burst-gradle-plugin/src/test/projects/multiplatform/lib/src/commonTest/kotlin/CoffeeTest.kt
+++ b/burst-gradle-plugin/src/test/projects/multiplatform/lib/src/commonTest/kotlin/CoffeeTest.kt
@@ -15,12 +15,15 @@
  */
 import app.cash.burst.Burst
 import kotlin.coroutines.coroutineContext
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 
 @Burst
@@ -28,6 +31,11 @@ class CoffeeTest(private val espresso: Espresso) {
   @BeforeTest
   fun setUp() {
     println("set up $espresso")
+  }
+
+  @AfterTest
+  fun tearDown() {
+    println("tear down $espresso")
   }
 
   @Test
@@ -44,7 +52,20 @@ class CoffeeTest(private val espresso: Espresso) {
       delay(1000.milliseconds)
       deferred.await()
     }
+
+  /**
+   * This test doesn't call `runTest()` directly, so Burst can't inline it. On Kotlin/JS the
+   * returned `TestResult` is a `Promise` that the test framework must receive to await the test.
+   */
+  @Test
+  fun coroutinesInHelperTest(dairy: Dairy) = runCoffeeTest {
+    delay(1000.milliseconds)
+    println("running $espresso $dairy in helper")
+  }
 }
+
+private fun runCoffeeTest(testBody: suspend TestScope.() -> Unit): TestResult =
+  runTest(testBody = testBody)
 
 enum class Espresso {
   Decaf,

--- a/burst-kotlin-plugin-tests/helpers/src/main/kotlin/app/cash/burst/test/helpers.kt
+++ b/burst-kotlin-plugin-tests/helpers/src/main/kotlin/app/cash/burst/test/helpers.kt
@@ -23,8 +23,8 @@ inline fun <reified T> loadClassInstance(specialization: String): T {
   return constructor.newInstance() as T
 }
 
-inline fun <reified T> T.invokeSpecialization(specialization: String) {
-  T::class.java.getMethod(specialization).invoke(this)
+inline fun <reified T> T.invokeSpecialization(specialization: String): Any? {
+  return T::class.java.getMethod(specialization).invoke(this)
 }
 
 inline val KClass<*>.testSuffixes: List<String>

--- a/burst-kotlin-plugin-tests/src/test/data/box/coroutines/CoroutinesInHelperFunction.kt
+++ b/burst-kotlin-plugin-tests/src/test/data/box/coroutines/CoroutinesInHelperFunction.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.burst.Burst
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+/**
+ * This test doesn't call `runTest()` directly. It calls a helper that does, and returns that
+ * helper's result. On Kotlin/JS a `TestResult` is a `Promise` that the test framework must receive
+ * in order to await the test, so each generated specialization must return the delegate's result.
+ */
+@Burst
+class CoffeeTest {
+  val log = mutableListOf<String>()
+
+  @Test
+  fun test(espresso: Espresso): CoffeeTestResult = runCoffeeTest {
+    delay(1000.milliseconds)
+    log += "running $espresso"
+  }
+
+  private fun runCoffeeTest(testBody: suspend TestScope.() -> Unit): CoffeeTestResult {
+    runTest(testBody = testBody)
+    return CoffeeTestResult(log.toList())
+  }
+}
+
+/**
+ * Stands in for `kotlinx.coroutines.test.TestResult`, which is a typealias for `Unit` on the JVM.
+ */
+class CoffeeTestResult(val log: List<String>)
+
+enum class Espresso {
+  Decaf,
+  Regular,
+  Double,
+}
+
+fun box(): String {
+  val instance = CoffeeTest()
+
+  val result = instance.invokeSpecialization("test_Decaf")
+  assertThat(result).isNotNull().isInstanceOf<CoffeeTestResult>()
+  assertThat((result as CoffeeTestResult).log).containsExactly("running Decaf")
+
+  return "OK"
+}

--- a/burst-kotlin-plugin-tests/src/test/data/dump/ir/FunctionReturnValue.fir.kt.txt
+++ b/burst-kotlin-plugin-tests/src/test/data/dump/ir/FunctionReturnValue.fir.kt.txt
@@ -1,0 +1,60 @@
+@Burst
+class CoffeeTest {
+  constructor() /* primary */ {
+    super/*Any*/()
+    /* <init>() */
+
+  }
+
+  private fun brew(espresso: Espresso): String {
+    return "brewing " + espresso
+  }
+
+  fun test(espresso: Espresso): String {
+    return <this>.brew(espresso = espresso)
+  }
+
+  @Test
+  fun test_Decaf(): String {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Decaf: Espresso = Espresso.Decaf
+    return tmp0_receiver.test(espresso = tmp1_Decaf)
+  }
+
+  @Test
+  fun test_Double(): String {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Double: Espresso = Espresso.Double
+    return tmp0_receiver.test(espresso = tmp1_Double)
+  }
+
+  @Test
+  fun test_Regular(): String {
+    val tmp0_receiver: CoffeeTest = <this>
+    val tmp1_Regular: Espresso = Espresso.Regular
+    return tmp0_receiver.test(espresso = tmp1_Regular)
+  }
+
+}
+
+enum class Espresso : Enum<Espresso> {
+  Decaf = Espresso()
+
+  Regular = Espresso()
+
+  Double = Espresso()
+
+  private constructor() /* primary */ {
+    super/*Enum*/<Espresso>()
+    /* <init>() */
+
+  }
+
+  /* static */ fun valueOf(value: String): Espresso /* Synthetic body for ENUM_VALUEOF */
+
+  /* static */ fun values(): Array<Espresso> /* Synthetic body for ENUM_VALUES */
+
+  /* static */ val entries: EnumEntries<Espresso>
+    get(): EnumEntries<Espresso> /* Synthetic body for ENUM_ENTRIES */
+
+}

--- a/burst-kotlin-plugin-tests/src/test/data/dump/ir/FunctionReturnValue.kt
+++ b/burst-kotlin-plugin-tests/src/test/data/dump/ir/FunctionReturnValue.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import app.cash.burst.Burst
+import kotlin.test.Test
+
+@Burst
+class CoffeeTest {
+  @Test fun test(espresso: Espresso): String = brew(espresso)
+
+  private fun brew(espresso: Espresso) = "brewing $espresso"
+}
+
+enum class Espresso {
+  Decaf,
+  Regular,
+  Double,
+}

--- a/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/BoxTestGenerated.java
+++ b/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/BoxTestGenerated.java
@@ -183,5 +183,11 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testCoroutinesAndTestComposition() {
       run("CoroutinesAndTestComposition.kt");
     }
+
+    @Test
+    @TestMetadata("CoroutinesInHelperFunction.kt")
+    public void testCoroutinesInHelperFunction() {
+      run("CoroutinesInHelperFunction.kt");
+    }
   }
 }

--- a/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/IrDumpTestGenerated.java
+++ b/burst-kotlin-plugin-tests/src/test/java/app/cash/burst/kotlin/IrDumpTestGenerated.java
@@ -51,6 +51,12 @@ public class IrDumpTestGenerated extends AbstractIrDumpTest {
     }
 
     @Test
+    @TestMetadata("FunctionReturnValue.kt")
+    public void testFunctionReturnValue() {
+      run("FunctionReturnValue.kt");
+    }
+
+    @Test
     @TestMetadata("IgnoreAnnotation.kt")
     public void testIgnoreAnnotation() {
       run("IgnoreAnnotation.kt");

--- a/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/FunctionSpecializer.kt
+++ b/burst-kotlin-plugin/src/main/kotlin/app/cash/burst/kotlin/FunctionSpecializer.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.isUnit
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 import org.jetbrains.kotlin.name.Name
@@ -262,7 +263,12 @@ internal class FunctionSpecializer(
         }
 
         is TestFunction.NonSuspending -> {
-          +callDelegate
+          when {
+            // Return the delegate's result. On Kotlin/JS, a test may return a `TestResult` (a
+            // `Promise`) that the test framework must receive in order to await the test.
+            !delegate.returnType.isUnit() -> +irReturn(callDelegate)
+            else -> +callDelegate
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

`FunctionSpecializer.createFunction()` copies the delegate's return type onto each generated specialization, but the `TestFunction.NonSuspending` branch emits the delegate call as a bare statement. When the original `@Test` function returns something other than `Unit`, the specialization silently returns nothing.

The practical case is a parameterized test that gets its `TestResult` from a helper that calls `runTest()`, rather than calling `runTest()` directly (which Burst recognizes and inlines). On Kotlin/JS a `TestResult` is a `Promise` that the test framework must receive to await the test, so:

- without an `@AfterTest`, every specialization passes immediately without its body finishing;
- with an `@AfterTest`, the Kotlin/JS test wrapper casts the `undefined` result to `Promise` and fails with `ClassCastException`.

Found in square/workflow-kotlin, where a test had to be restructured to call `runTest()` directly as a workaround (square/workflow-kotlin#1571). Observed on Burst 2.13.0.

## Fix

In the `NonSuspending` branch, emit `return <delegate call>` when the delegate's return type is not `Unit`, mirroring the `Suspending` branch a few lines up. `Unit`-returning tests keep the plain statement, so existing IR dumps are unchanged.

`ClassSpecializer` doesn't have the same problem: its generated subclasses inherit the test functions as fake overrides instead of delegating to them.

## Tests

- New box test `CoroutinesInHelperFunction.kt` invokes a specialization via reflection and asserts it returns the helper's result. It fails with `expected to not be null` before the fix. (`invokeSpecialization` now returns the invoked method's result.)
- New IR dump `FunctionReturnValue.kt` shows `return tmp0_receiver.test(...)` in each specialization.
- The `multiplatform` Gradle functional project gains `coroutinesInHelperTest`, which returns a `TestResult` from a helper, plus an `@AfterTest`. Before the fix `multiplatformJs` fails with three `ClassCastException`s; the JVM, JS, and native variants all pass after.

`:burst-kotlin-plugin-tests:test` passes (78 tests), and the three `multiplatform*` functional tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
